### PR TITLE
Improve import/build compatibility for markdown-it-cjk-friendly

### DIFF
--- a/packages/markdown-it-cjk-friendly/src/index.ts
+++ b/packages/markdown-it-cjk-friendly/src/index.ts
@@ -60,7 +60,7 @@ function nonEmojiGeneralUseVS(uc: number) {
   return uc >= 0xfe00 && uc <= 0xfe0e;
 }
 
-export default function markdownItCjFriendlyPlugin(md: MarkdownIt): void {
+function markdownItCjFriendlyPlugin(md: MarkdownIt): void {
   const PreviousState = md.inline.State;
 
   class CjFriendlyState extends PreviousState {
@@ -153,3 +153,5 @@ export default function markdownItCjFriendlyPlugin(md: MarkdownIt): void {
 
   md.inline.State = CjFriendlyState;
 }
+
+export default markdownItCjFriendlyPlugin;


### PR DESCRIPTION
## Problem

There's a mismatch between TypeScript definitions and the actual JavaScript exports, and when I try to import `markdown-it-cjk-friendly` as explained in README, this error is shown:

![Screenshot 2025-09-21 at 10 14 56 AM](https://github.com/user-attachments/assets/ebe718e1-af7b-4f3c-9ed6-bc2a53c3c047)

This is hidden when I change the code like this:

```ts
import { MarkdownItCjkFriendly } from "markdown-it-cjk-friendly";
```

But then it causes this build error:

```
src/converters/markdown-it-gfm-cjk-friendly.ts (3:9): "MarkdownItCjkFriendly" is not exported by "node_modules/markdown-it-cjk-friendly/dist/index.js", imported by "src/converters/markdown-it-gfm-cjk-friendly.ts".
file: /Users/manabu/workplace/Docsloth/js/src/converters/markdown-it-gfm-cjk-friendly.ts:3:9

1: import type { MarkdownItOptions } from "@/types/markdown-it-options";
2: import MarkdownIt from "markdown-it";
3: import { MarkdownItCjkFriendly } from "markdown-it-cjk-friendly";
            ^
```

## Cause

This seems to be caused because `dist/index.js` only has a default export while `index.d.ts` has a named export.

## Change

I changed the code to align `dist/index.js` and `dist/index.d.ts` to have a default import.

---

Thanks so much for maintaining this package!