### PR TITLE
chore: fix package.json repository fields for monorepos

### DIFF
--- a/.changeset/quiet-maps-help.md
+++ b/.changeset/quiet-maps-help.md
@@ -1,0 +1,6 @@
+---
+"remark-cjk-friendly": patch
+"remark-cjk-friendly-gfm-strikethrough": patch
+---
+
+Add package directory metadata to the remark packages.

--- a/.changeset/quiet-maps-help.md
+++ b/.changeset/quiet-maps-help.md
@@ -1,6 +1,13 @@
 ---
+"markdown-it-cjk-friendly": patch
+"marked-cjk-friendly": patch
+"mdast-util-to-markdown-cjk-friendly": patch
+"mdast-util-to-markdown-cjk-friendly-gfm-strikethrough": patch
+"micromark-extension-cjk-friendly": patch
+"micromark-extension-cjk-friendly-gfm-strikethrough": patch
+"micromark-extension-cjk-friendly-util": patch
 "remark-cjk-friendly": patch
 "remark-cjk-friendly-gfm-strikethrough": patch
 ---
 
-Add package directory metadata to the remark packages.
+Add package directory metadata to the CJK-friendly packages.

--- a/.changeset/quiet-maps-help.md
+++ b/.changeset/quiet-maps-help.md
@@ -10,4 +10,4 @@
 "remark-cjk-friendly-gfm-strikethrough": patch
 ---
 
-Add package directory metadata to the CJK-friendly packages.
+Fix package.json repository fields for monorepos.

--- a/packages/markdown-it-cjk-friendly/package.json
+++ b/packages/markdown-it-cjk-friendly/package.json
@@ -17,7 +17,9 @@
     "README.md"
   ],
   "repository": {
-    "url": "https://github.com/tats-u/markdown-cjk-friendly"
+    "type": "git",
+    "url": "git+https://github.com/tats-u/markdown-cjk-friendly.git",
+    "directory": "packages/markdown-it-cjk-friendly"
   },
   "license": "MIT",
   "author": "Tatsunori Uchino <tats.u@live.jp> (https://github.com/tats-u)",

--- a/packages/marked-cjk-friendly/package.json
+++ b/packages/marked-cjk-friendly/package.json
@@ -17,7 +17,9 @@
     "README.md"
   ],
   "repository": {
-    "url": "https://github.com/tats-u/markdown-cjk-friendly"
+    "type": "git",
+    "url": "git+https://github.com/tats-u/markdown-cjk-friendly.git",
+    "directory": "packages/marked-cjk-friendly"
   },
   "license": "MIT",
   "author": "Tatsunori Uchino <tats.u@live.jp> (https://github.com/tats-u)",

--- a/packages/mdast-util-to-markdown-cjk-friendly-gfm-strikethrough/package.json
+++ b/packages/mdast-util-to-markdown-cjk-friendly-gfm-strikethrough/package.json
@@ -17,7 +17,9 @@
     "README.md"
   ],
   "repository": {
-    "url": "https://github.com/tats-u/markdown-cjk-friendly"
+    "type": "git",
+    "url": "git+https://github.com/tats-u/markdown-cjk-friendly.git",
+    "directory": "packages/mdast-util-to-markdown-cjk-friendly-gfm-strikethrough"
   },
   "license": "MIT",
   "author": "Tatsunori Uchino <tats.u@live.jp> (https://github.com/tats-u)",

--- a/packages/mdast-util-to-markdown-cjk-friendly/package.json
+++ b/packages/mdast-util-to-markdown-cjk-friendly/package.json
@@ -17,7 +17,9 @@
     "README.md"
   ],
   "repository": {
-    "url": "https://github.com/tats-u/markdown-cjk-friendly"
+    "type": "git",
+    "url": "git+https://github.com/tats-u/markdown-cjk-friendly.git",
+    "directory": "packages/mdast-util-to-markdown-cjk-friendly"
   },
   "license": "MIT",
   "author": "Tatsunori Uchino <tats.u@live.jp> (https://github.com/tats-u)",

--- a/packages/micromark-extension-cjk-friendly-gfm-strikethrough/package.json
+++ b/packages/micromark-extension-cjk-friendly-gfm-strikethrough/package.json
@@ -17,7 +17,9 @@
     "README.md"
   ],
   "repository": {
-    "url": "https://github.com/tats-u/markdown-cjk-friendly"
+    "type": "git",
+    "url": "git+https://github.com/tats-u/markdown-cjk-friendly.git",
+    "directory": "packages/micromark-extension-cjk-friendly-gfm-strikethrough"
   },
   "license": "MIT",
   "author": "Tatsunori Uchino <tats.u@live.jp> (https://github.com/tats-u)",

--- a/packages/micromark-extension-cjk-friendly-util/package.json
+++ b/packages/micromark-extension-cjk-friendly-util/package.json
@@ -17,7 +17,9 @@
     "README.md"
   ],
   "repository": {
-    "url": "https://github.com/tats-u/markdown-cjk-friendly"
+    "type": "git",
+    "url": "git+https://github.com/tats-u/markdown-cjk-friendly.git",
+    "directory": "packages/micromark-extension-cjk-friendly-util"
   },
   "license": "MIT",
   "author": "Tatsunori Uchino <tats.u@live.jp> (https://github.com/tats-u)",

--- a/packages/micromark-extension-cjk-friendly/package.json
+++ b/packages/micromark-extension-cjk-friendly/package.json
@@ -17,7 +17,9 @@
     "README.md"
   ],
   "repository": {
-    "url": "https://github.com/tats-u/markdown-cjk-friendly"
+    "type": "git",
+    "url": "git+https://github.com/tats-u/markdown-cjk-friendly.git",
+    "directory": "packages/micromark-extension-cjk-friendly"
   },
   "license": "MIT",
   "author": "Tatsunori Uchino <tats.u@live.jp> (https://github.com/tats-u)",

--- a/packages/remark-cjk-friendly-gfm-strikethrough/package.json
+++ b/packages/remark-cjk-friendly-gfm-strikethrough/package.json
@@ -17,7 +17,9 @@
     "README.md"
   ],
   "repository": {
-    "url": "https://github.com/tats-u/markdown-cjk-friendly"
+    "type": "git",
+    "url": "git+https://github.com/tats-u/markdown-cjk-friendly.git",
+    "directory": "packages/remark-cjk-friendly-gfm-strikethrough"
   },
   "license": "MIT",
   "author": "Tatsunori Uchino <tats.u@live.jp> (https://github.com/tats-u)",

--- a/packages/remark-cjk-friendly/package.json
+++ b/packages/remark-cjk-friendly/package.json
@@ -17,7 +17,9 @@
     "README.md"
   ],
   "repository": {
-    "url": "https://github.com/tats-u/markdown-cjk-friendly"
+    "type": "git",
+    "url": "git+https://github.com/tats-u/markdown-cjk-friendly.git",
+    "directory": "packages/remark-cjk-friendly"
   },
   "license": "MIT",
   "author": "Tatsunori Uchino <tats.u@live.jp> (https://github.com/tats-u)",


### PR DESCRIPTION
## Summary
- add package-level `repository.type`, `repository.url`, and `repository.directory` metadata for all CJK-friendly packages except `markdown-it-cj-friendly`
- keep the already-correct `markdown-it-cj-friendly` package unchanged because it belongs to the CJ-friendly repository
- expand the patch changeset to cover every updated package manifest
- keep runtime code, dependencies, current version fields, exports, and published file lists unchanged

## Why
These packages are published from a monorepo. Adding `repository.directory` lets npm and package tooling link directly to each package source directory instead of only the repository root.

## Verification
- `node --run fix`
- metadata assertion for all package manifests, excluding `markdown-it-cj-friendly`
- `git diff --check`
- `corepack pnpm exec changeset status`